### PR TITLE
Fix: Missing image size conversion for vx-disparity

### DIFF
--- a/include/gpu_stereo_image_proc/libsgm_sgbm_processor.h
+++ b/include/gpu_stereo_image_proc/libsgm_sgbm_processor.h
@@ -47,7 +47,8 @@ public:
     stereo_matcher_.reset(new sgm::LibSGMWrapper(disparity_range_, P1_, P2_, uniqueness_ratio_, true));
   }
 
-  virtual void processDisparity(const cv::Mat& left_rect, const cv::Mat& right_rect,
+  virtual void processDisparity(const cv::Mat&                           left_rect,
+                                const cv::Mat&                           right_rect,
                                 const image_geometry::StereoCameraModel& model,
                                 stereo_msgs::DisparityImage&             disparity) const;
 
@@ -57,9 +58,17 @@ public:
     ROS_INFO("Uniqueness  : %5.1f", uniqueness_ratio_);
     ROS_INFO("P1/P2       : P1 %d, P2, %d", P1_, P2_);
     ROS_INFO("Min/Max Disp: min %d, max %d", min_disparity_, max_disparity_);
-    ROS_INFO("Path Type   : %s", (path_type_ == sgm::PathType::SCAN_4PATH ? "SCAN_4PATH" : "SCAN_8PATH" ));
+    ROS_INFO("Path Type   : %s", (path_type_ == sgm::PathType::SCAN_4PATH ? "SCAN_4PATH" : "SCAN_8PATH"));
     ROS_INFO("===================================");
-    stereo_matcher_.reset(new sgm::LibSGMWrapper(disparity_range_, P1_, P2_, uniqueness_ratio_, true, path_type_, min_disparity_));
+    stereo_matcher_.reset(
+        new sgm::LibSGMWrapper(disparity_range_, P1_, P2_, uniqueness_ratio_, true, path_type_, min_disparity_));
+  }
+
+  bool setImageSize(cv::Size image_size)
+  {
+    ROS_WARN("Member variable 'image_size_' is not currently used.");
+    image_size_ = image_size;
+    return true;
   }
 
   float getUniquenessRatio() const
@@ -132,12 +141,10 @@ public:
     return ret;
   }
 
-
-
 private:
   std::shared_ptr<sgm::LibSGMWrapper> stereo_matcher_;
 
-  float uniqueness_ratio_;
+  float         uniqueness_ratio_;
   sgm::PathType path_type_;
 };
 

--- a/include/gpu_stereo_image_proc/sgbm_processor.h
+++ b/include/gpu_stereo_image_proc/sgbm_processor.h
@@ -74,11 +74,18 @@ public:
     ALL        = LEFT_ALL | RIGHT_ALL | STEREO_ALL
   };
 
-  StereoSGBMProcessor() : image_size_(640, 480), min_disparity_(0), max_disparity_(128), disparity_range_(64), P1_(200), P2_(400)
+  StereoSGBMProcessor()
+    : image_size_(640, 480), min_disparity_(0), max_disparity_(128), disparity_range_(64), P1_(200), P2_(400)
   {
   }
 
   virtual ~StereoSGBMProcessor(){};
+
+  cv::Size getImageSize() const
+  {
+    return image_size_;
+  }
+  virtual bool setImageSize(cv::Size image_size);
 
   int  getInterpolation() const;
   void setInterpolation(int interp);
@@ -95,15 +102,17 @@ public:
   int  getDisparityRange() const;
   bool setDisparityRange(int range);
 
-  int  getP1() const
-  {return P1_;}
+  int getP1() const
+  {
+    return P1_;
+  }
   void setP1(int P1)
   {
     ROS_INFO("%s, in %d", __func__, P1);
     P1_ = P1;
   }
 
-  int  getP2() const
+  int getP2() const
   {
     return P2_;
   }
@@ -113,18 +122,28 @@ public:
     P2_ = P2;
   }
 
-  bool process(const sensor_msgs::ImageConstPtr& left_raw, const sensor_msgs::ImageConstPtr& right_raw,
-               const image_geometry::StereoCameraModel& model, StereoImageSet& output, ImageProcFlag flags) const;
+  bool process(const sensor_msgs::ImageConstPtr&        left_raw,
+               const sensor_msgs::ImageConstPtr&        right_raw,
+               const image_geometry::StereoCameraModel& model,
+               StereoImageSet&                          output,
+               ImageProcFlag                            flags) const;
 
-  virtual void processDisparity(const cv::Mat& left_rect, const cv::Mat& right_rect,
+  virtual void processDisparity(const cv::Mat&                           left_rect,
+                                const cv::Mat&                           right_rect,
                                 const image_geometry::StereoCameraModel& model,
                                 stereo_msgs::DisparityImage&             disparity) const;
 
-  void processPoints(const stereo_msgs::DisparityImage& disparity, const cv::Mat& color, const std::string& encoding,
-                     const image_geometry::StereoCameraModel& model, sensor_msgs::PointCloud& points) const;
+  void processPoints(const stereo_msgs::DisparityImage&       disparity,
+                     const cv::Mat&                           color,
+                     const std::string&                       encoding,
+                     const image_geometry::StereoCameraModel& model,
+                     sensor_msgs::PointCloud&                 points) const;
 
-  void processPoints2(const stereo_msgs::DisparityImage& disparity, const cv::Mat& coloer, const std::string& encoding,
-                      const image_geometry::StereoCameraModel& model, sensor_msgs::PointCloud2& points) const;
+  void processPoints2(const stereo_msgs::DisparityImage&       disparity,
+                      const cv::Mat&                           coloer,
+                      const std::string&                       encoding,
+                      const image_geometry::StereoCameraModel& model,
+                      sensor_msgs::PointCloud2&                points) const;
 
 protected:
   image_proc::Processor       mono_processor_;

--- a/include/gpu_stereo_image_proc/sgbm_processor.h
+++ b/include/gpu_stereo_image_proc/sgbm_processor.h
@@ -85,7 +85,7 @@ public:
   {
     return image_size_;
   }
-  virtual bool setImageSize(cv::Size image_size);
+  virtual bool setImageSize(cv::Size image_size) = 0;
 
   int  getInterpolation() const;
   void setInterpolation(int interp);

--- a/include/gpu_stereo_image_proc/vx_sgbm_processor.h
+++ b/include/gpu_stereo_image_proc/vx_sgbm_processor.h
@@ -48,7 +48,8 @@ public:
     stereo_matcher_.reset(new VXStereoMatcher(image_size_.width, image_size_.height));
   }
 
-  virtual void processDisparity(const cv::Mat& left_rect, const cv::Mat& right_rect,
+  virtual void processDisparity(const cv::Mat&                           left_rect,
+                                const cv::Mat&                           right_rect,
                                 const image_geometry::StereoCameraModel& model,
                                 stereo_msgs::DisparityImage&             disparity) const;
 
@@ -69,6 +70,17 @@ public:
     stereo_matcher_.reset(new VXStereoMatcher(image_size_.width, image_size_.height, shrink_scale_, min_disparity_,
                                               max_disparity_, P1_, P2_, sad_win_size_, ct_win_size_, hc_win_size_,
                                               clip_, max_diff_, uniqueness_ratio_, scanline_mask_, flags_));
+  }
+
+  bool setImageSize(cv::Size image_size)
+  {
+    if(image_size.width % 4 != 0)
+    {
+      ROS_WARN("Image Width must be divisible by 4.");
+      return false;
+    }
+    image_size_ = image_size;
+    return true;
   }
 
   float getUniquenessRatio() const


### PR DESCRIPTION
- Add getter and setter of image_size for vx-disparity.
- Automatically change processor's image size when incoming image size does not match processor's.